### PR TITLE
Enforce python2 usage

### DIFF
--- a/build/cmakeconfgen.py
+++ b/build/cmakeconfgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief CMake Config file generator
 # @date $Date$

--- a/build/codegen.py
+++ b/build/codegen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 # @file codegen.py
 # @brief simple code template generator

--- a/build/ezt.py
+++ b/build/ezt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """ezt.py -- easy templating
 
 ezt templates are very similar to standard HTML files.  But additionally

--- a/build/makevcproj.py
+++ b/build/makevcproj.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief Visual Studio Project file generator
 # @date $Date: 2007-07-20 15:36:59 $

--- a/build/makewrapper.py
+++ b/build/makewrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief CORBA stub and skelton wrapper generator
 # @date $Date: 2008-02-29 04:50:39 $

--- a/build/makewxs.py
+++ b/build/makewxs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief WiX wxsd file generator
 # @date $Date: 2008-02-26 13:58:13 $

--- a/build/pickupprojs.py
+++ b/build/pickupprojs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief Visual Studio Project GUID pickup script
 # @date $Date: 2007-07-20 15:37:16 $

--- a/build/setuptest.py
+++ b/build/setuptest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @file setuptest.py
 # @brief CppUnit test environment setup script

--- a/build/slntool.py
+++ b/build/slntool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief Visual Studio solution generator
 # @date $Date: 2008-03-06 06:46:37 $

--- a/build/uuid.py
+++ b/build/uuid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 r"""UUID objects (universally unique identifiers) according to RFC 4122.
 

--- a/build/vcprojtool.py
+++ b/build/vcprojtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief VCProject file generator
 # @date $Date: 2008-02-29 04:52:14 $

--- a/build/vcxprojtool.py
+++ b/build/vcxprojtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief VCXProject file generator
 # @date $Date: 2008-02-29 04:52:14 $

--- a/build/vsprops2cmake.py
+++ b/build/vsprops2cmake.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from xml.dom import minidom, Node
 import sys

--- a/build/yat.py
+++ b/build/yat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief YAT: YAml Template text processor
 # @date $Date: 2008-02-09 20:04:27 $

--- a/examples/AutoTest/ConnectTest.py
+++ b/examples/AutoTest/ConnectTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## ConnectTest.py

--- a/examples/AutoTest/CorbaNaming.py
+++ b/examples/AutoTest/CorbaNaming.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 
 

--- a/examples/AutoTest/TestsConnection.py
+++ b/examples/AutoTest/TestsConnection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## ConnectTest.py

--- a/examples/AutoTest/rtc_handle.py
+++ b/examples/AutoTest/rtc_handle.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#/usr/bin/env python2
 # -*- Python -*-
 
 import sys

--- a/examples/tests/AddRemoveMemberSDOPackageTest.py
+++ b/examples/tests/AddRemoveMemberSDOPackageTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## AddRemoveMemberSDOPackageTest.py

--- a/examples/tests/AddRemoveOrganizationSDOPackageTest.py
+++ b/examples/tests/AddRemoveOrganizationSDOPackageTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## AddRemoveOrganizationSDOPackageTest.py

--- a/examples/tests/AddRemoveRTCTest.py
+++ b/examples/tests/AddRemoveRTCTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## AddRemoveRTCTest.py

--- a/examples/tests/AttachDetachRTCTest.py
+++ b/examples/tests/AttachDetachRTCTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## AttachDetachRTCTest.py

--- a/examples/tests/ConfigurationSDOPackageTest.py
+++ b/examples/tests/ConfigurationSDOPackageTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## ConfigurationSDOPackageTest.py

--- a/examples/tests/ConnectRTCTest.py
+++ b/examples/tests/ConnectRTCTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## ConnectRTCTest.py

--- a/examples/tests/CorbaNaming.py
+++ b/examples/tests/CorbaNaming.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 
 

--- a/examples/tests/CreateDeleteRTCTest.py
+++ b/examples/tests/CreateDeleteRTCTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## CreateDeleteRTCTest.py

--- a/examples/tests/DataPortTest.py
+++ b/examples/tests/DataPortTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## DataPortTest.py

--- a/examples/tests/ManagerTest.py
+++ b/examples/tests/ManagerTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## ManagerTest.py

--- a/examples/tests/OrganizationSDOPackageTest.py
+++ b/examples/tests/OrganizationSDOPackageTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## OrganizationSDOPackageTest.py

--- a/examples/tests/RTCTest.py
+++ b/examples/tests/RTCTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## RTCTest.py

--- a/examples/tests/SDOPackageTest.py
+++ b/examples/tests/SDOPackageTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## SDOPackageTest.py

--- a/examples/tests/ServiceProfileSDOPackageTest.py
+++ b/examples/tests/ServiceProfileSDOPackageTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## ServiceProfileSDOPackageTest.py

--- a/examples/tests/SetMemberSDOPackageTest.py
+++ b/examples/tests/SetMemberSDOPackageTest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: euc-jp -*-
 #
 ## SetMemberSDOPackageTest.py

--- a/examples/tests/rtc_handle.py
+++ b/examples/tests/rtc_handle.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#/usr/bin/env python2
 # -*- Python -*-
 
 import sys

--- a/src/lib/coil/build/setuptest.py
+++ b/src/lib/coil/build/setuptest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @file setuptest.py
 # @brief CppUnit test environment setup script

--- a/src/lib/coil/build/slntool.py
+++ b/src/lib/coil/build/slntool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief Visual Studio solution generator
 # @date $Date: 2008-03-06 06:46:37 $

--- a/src/lib/coil/build/uuid.py
+++ b/src/lib/coil/build/uuid.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 r"""UUID objects (universally unique identifiers) according to RFC 4122.
 

--- a/src/lib/coil/build/vcprojtool.py
+++ b/src/lib/coil/build/vcprojtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief VCProject file generator
 # @date $Date: 2008-02-29 04:52:14 $

--- a/src/lib/coil/build/vcxprojtool.py
+++ b/src/lib/coil/build/vcxprojtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief VCXProject file generator
 # @date $Date: 2008-02-29 04:52:14 $

--- a/src/lib/coil/build/yat.py
+++ b/src/lib/coil/build/yat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief YAT: YAml Template text processor
 # @date $Date: 2008-02-09 20:04:27 $

--- a/src/lib/doil/utils/omniidl_be/Makefile.am
+++ b/src/lib/doil/utils/omniidl_be/Makefile.am
@@ -8,7 +8,7 @@
 noinst_DATA = __init__.py
 
 __init__.py:
-	echo "#!/usr/bin/env python" > createinit.py
+	echo "#!/usr/bin/env python2" > createinit.py
 	echo "import sys"            >> createinit.py
 	echo "import omniidl_be"     >> createinit.py
 	echo "path0 = '.'"   >> createinit.py

--- a/src/lib/doil/utils/omniidl_be/doil/__init__.py
+++ b/src/lib/doil/utils/omniidl_be/doil/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file omniidl_be/doil/__init__.py

--- a/src/lib/doil/utils/omniidl_be/doil/config.py
+++ b/src/lib/doil/utils/omniidl_be/doil/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 # @file omniidl_be/doil/config.py

--- a/src/lib/doil/utils/omniidl_be/doil/corba/__init__.py
+++ b/src/lib/doil/utils/omniidl_be/doil/corba/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: shift_jis -*-
 # -*- python -*-
 #

--- a/src/lib/doil/utils/omniidl_be/doil/corba/template.py
+++ b/src/lib/doil/utils/omniidl_be/doil/corba/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file template.py

--- a/src/lib/doil/utils/omniidl_be/doil/dictbuilder.py
+++ b/src/lib/doil/utils/omniidl_be/doil/dictbuilder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: sjis -*-
 # -*- python -*-
 #

--- a/src/lib/doil/utils/omniidl_be/doil/ice/__init__.py
+++ b/src/lib/doil/utils/omniidl_be/doil/ice/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file iceadapter/__init__.py

--- a/src/lib/doil/utils/omniidl_be/doil/interface/__init__.py
+++ b/src/lib/doil/utils/omniidl_be/doil/interface/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: shift_jis -*-
 # -*- python -*-
 # @file omniidl_be/doil/servant/__init__.py

--- a/src/lib/doil/utils/omniidl_be/doil/interface/template.py
+++ b/src/lib/doil/utils/omniidl_be/doil/interface/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: shift_jis -*-
 # -*- python -*-
 #

--- a/src/lib/doil/utils/omniidl_be/doil/util.py
+++ b/src/lib/doil/utils/omniidl_be/doil/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file util.py

--- a/src/lib/doil/utils/omniidl_be/doil/yat.py
+++ b/src/lib/doil/utils/omniidl_be/doil/yat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief YAT: YAml Template text processor
 # @date $Date: 2008-02-09 20:04:27 $

--- a/src/lib/doil/utils/omniidl_be/tests/unitTest/remake_servants.py
+++ b/src/lib/doil/utils/omniidl_be/tests/unitTest/remake_servants.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import os

--- a/src/lib/doil/utils/omniidl_be/tests/unitTest/setuptest.py
+++ b/src/lib/doil/utils/omniidl_be/tests/unitTest/setuptest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @file setuptest.py
 # @brief CppUnit test environment setup script

--- a/src/lib/doil/utils/omniidl_be/tests/unitTest/yat.py
+++ b/src/lib/doil/utils/omniidl_be/tests/unitTest/yat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief YAT: YAml Template text processor
 # @date $Date: 2008-02-09 20:04:27 $

--- a/utils/rtc-link/RtcLink.py
+++ b/utils/rtc-link/RtcLink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtcLink.py

--- a/utils/rtc-link/RtcLink.pyw
+++ b/utils/rtc-link/RtcLink.pyw
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtcLink.pyw

--- a/utils/rtc-link/RtmAbout.py
+++ b/utils/rtc-link/RtmAbout.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtmAbout.py

--- a/utils/rtc-link/RtmCompData.py
+++ b/utils/rtc-link/RtmCompData.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- Python -*-
 #
 #  @file RtmCompData.py

--- a/utils/rtc-link/RtmDialog.py
+++ b/utils/rtc-link/RtmDialog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*- 
 #
 #  @file RtmDialog.py

--- a/utils/rtc-link/RtmDtdValidator.py
+++ b/utils/rtc-link/RtmDtdValidator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtmDtdValidator.py

--- a/utils/rtc-link/RtmFrame.py
+++ b/utils/rtc-link/RtmFrame.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtmFrame.py

--- a/utils/rtc-link/RtmLineUtil.py
+++ b/utils/rtc-link/RtmLineUtil.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtmLineUtil.py

--- a/utils/rtc-link/RtmNSHelper.py
+++ b/utils/rtc-link/RtmNSHelper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtmNSHelper.py

--- a/utils/rtc-link/RtmParser.py
+++ b/utils/rtc-link/RtmParser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*- 
 #
 #  @file RtmParser.py

--- a/utils/rtc-link/RtmProfileList.py
+++ b/utils/rtc-link/RtmProfileList.py
@@ -1,4 +1,4 @@
-#/usr/bin/env python
+#/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtmProfileList.py

--- a/utils/rtc-link/RtmSystemDraw.py
+++ b/utils/rtc-link/RtmSystemDraw.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*- 
 #
 #  @file RtmSystemDraw.py

--- a/utils/rtc-link/RtmTreeCtrl.py
+++ b/utils/rtc-link/RtmTreeCtrl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 #  @file RtmTreeCtrl.py
 #  @brief rtc-link name tree management class

--- a/utils/rtc-link/rtc-link
+++ b/utils/rtc-link/rtc-link
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file rtc-link

--- a/utils/rtc-template/README_gen.py
+++ b/utils/rtc-template/README_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file README_src.py

--- a/utils/rtc-template/cxx_gen.py
+++ b/utils/rtc-template/cxx_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file cxx_gen.py

--- a/utils/rtc-template/cxx_svc_impl.py
+++ b/utils/rtc-template/cxx_svc_impl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file cxx_svc_impl.py

--- a/utils/rtc-template/gen_base.py
+++ b/utils/rtc-template/gen_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 # -*- condig shift_jis -*-
 #

--- a/utils/rtc-template/profile_gen.py
+++ b/utils/rtc-template/profile_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file profile_gen.py

--- a/utils/rtc-template/python_gen.py
+++ b/utils/rtc-template/python_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- Python -*-
 #
 #  @file Py_src.py
@@ -120,7 +120,7 @@ bind_config = """
 #------------------------------------------------------------
 # Python component source code template
 #------------------------------------------------------------
-py_source = """#!/usr/bin/env python
+py_source = """#!/usr/bin/env python2
 # -*- Python -*-
 
 import sys

--- a/utils/rtc-template/rtc-template
+++ b/utils/rtc-template/rtc-template
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file rtc-template

--- a/utils/rtc-template/test-template.py
+++ b/utils/rtc-template/test-template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 #
 #  @file cxx_gen.py

--- a/utils/rtc-template/vcproj_gen.py
+++ b/utils/rtc-template/vcproj_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- Python -*-
 #
 #  @file vcproj_gen.py

--- a/utils/rtm-manager/NSHelper.py
+++ b/utils/rtm-manager/NSHelper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file RtmNSHelper.py

--- a/utils/rtm-manager/rtm-manager
+++ b/utils/rtm-manager/rtm-manager
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from Tkinter import *
 from tkFont import *

--- a/utils/rtm-skelwrapper/rtm-skelwrapper
+++ b/utils/rtm-skelwrapper/rtm-skelwrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- python -*-
 # -*- coding: utf-8 -*-
 #

--- a/utils/rtm-skelwrapper/skel_wrapper.py
+++ b/utils/rtm-skelwrapper/skel_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #  @file skel_wrapper.py

--- a/win32/OpenRTM-aist/installer/OpenCV-RTC/opencvrtcwxs.py
+++ b/win32/OpenRTM-aist/installer/OpenCV-RTC/opencvrtcwxs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief WiX wxs file generator for omniORB
 # @date $Date$

--- a/win32/OpenRTM-aist/installer/OpenCV2.1/opencvwxs.py
+++ b/win32/OpenRTM-aist/installer/OpenCV2.1/opencvwxs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief WiX wxs file generator for omniORB
 # @date $Date$

--- a/win32/OpenRTM-aist/installer/OpenRTP/openrtpwxs.py
+++ b/win32/OpenRTM-aist/installer/OpenRTP/openrtpwxs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief WiX wxs file generator for omniORB
 # @date $Date$

--- a/win32/OpenRTM-aist/installer/omniORB/omniwxs.py
+++ b/win32/OpenRTM-aist/installer/omniORB/omniwxs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # @brief WiX wxs file generator for omniORB
 # @date $Date$


### PR DESCRIPTION
This allows building on 20.04 without enforcing the `python-is-python2` package.